### PR TITLE
add org id as a connect arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Release History
 * Override get_columns in DatabricksDialect to account for differences in Databricks and OSS Hive partition header
 * Fix version file
 * Update black and add isort
+* Add org id argument for connection
 
 
 0.3.0: 2019-08-14

--- a/databricks_dbapi/databricks.py
+++ b/databricks_dbapi/databricks.py
@@ -14,26 +14,34 @@ threadsafety = hive.threadsafety
 paramstyle = hive.paramstyle
 
 
-def connect(host, port=443, database="default", cluster=None, http_path=None, token=None, user=None, password=None):
+def connect(
+    host, port=443, database="default", cluster=None, http_path=None, token=None, user=None, password=None, org=0
+):
     """Create a Hive DBAPI connection to an interactive Databricks cluster.
 
     Create a DBAPI connection to a Databricks cluster, which can be used to generate
-    DBAPI cursor(s). Provide either a cluster name OR an http_path from the cluster's
-    JDBC/ODBC connection details. If using Azure, http_path is required. On
-    instantiation, http_path is prioritized over cluster.
+    DBAPI cursor(s). Provide either a ``cluster`` OR an ``http_path`` from the cluster's
+    JDBC/ODBC connection details. If using Azure, ``http_path`` is required. On
+    instantiation, ``http_path`` is prioritized over ``cluster`` and ``org``.
 
-    For authentication, provide either a token OR both a user and password. Token
-    authentication is strongly preferred.
+    For authentication, provide either a ``token`` OR both a ``user`` and ``password``.
+    Token authentication is strongly recommended over passwords.
+
+    The simplest connection requires providing args ``host``, ``http_path``, and
+    ``token``.
 
     :param str host: the server hostname from the cluster's JDBC/ODBC connection page.
     :param int port: the port number from the cluster's JDBC/ODBC connection page.
     :param str database: the database to use
-    :param str cluster: the cluster unique name or alias.
+    :param str cluster: the cluster unique name or alias. Not required if passing
+        ``http_path``
     :param str http_path: the HTTP Path as shown in the cluster's JDBC/ODBC connection
         page. Required if using Azure platform.
     :param str token: a Databricks API token.
     :param str user: a Databricks user name.
     :param str password: the corresponding Databricks user's password.
+    :param str org: the org id associated with the Databricks workspace (E2). Not
+        required if passing ``http_path``.
     """
     if token is not None:
         auth = "token:%s" % token
@@ -42,6 +50,7 @@ def connect(host, port=443, database="default", cluster=None, http_path=None, to
     else:
         raise ValueError("Missing arguments. Must provide either token or user/password.")
 
+    # https://kb.databricks.com/python/python-2-eol.html
     if PY_MAJOR < 3:
         auth = base64.standard_b64encode(auth)
     else:
@@ -50,7 +59,7 @@ def connect(host, port=443, database="default", cluster=None, http_path=None, to
     if http_path is not None:
         url = "https://%s:%s/%s" % (host, port, http_path)
     elif cluster is not None:
-        url = "https://%s:%s/sql/protocolv1/o/0/%s" % (host, port, cluster)
+        url = "https://%s:%s/sql/protocolv1/o/%s/%s" % (host, port, org, cluster)
     else:
         raise ValueError("Missing arguments. Must provide either cluster or http_path.")
 

--- a/databricks_dbapi/databricks.py
+++ b/databricks_dbapi/databricks.py
@@ -40,8 +40,8 @@ def connect(
     :param str token: a Databricks API token.
     :param str user: a Databricks user name.
     :param str password: the corresponding Databricks user's password.
-    :param str org: the org id associated with the Databricks workspace (E2). Not
-        required if passing ``http_path``.
+    :param str org: the org id associated with the Databricks workspace (E2). Required
+        for E2 if not passing ``http_path``. Not required if passing ``http_path``.
     """
     if token is not None:
         auth = "token:%s" % token


### PR DESCRIPTION
Add org id as a connection arg. Org ID is no longer zero for databricks E2 workspaces and replaces the `/0/` in the `http_path`