### PR TITLE
make hive and odbc dependencies optional

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 python 3.7.4
-poetry 1.1.4
+poetry 1.1.11

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release History
 ---------------
 
+0.6.0: 2021-11-21
+~~~~~~~~~~~~~~~~~
+
+* pyhive is now an optional dependency. Either ``hive`` or ``odbc`` or both must be specified as an extra.
+
 0.5.0: 2021-02-25
 ~~~~~~~~~~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release History
 0.6.0: 2021-11-21
 ~~~~~~~~~~~~~~~~~
 
-* pyhive is now an optional dependency. Either ``hive`` or ``odbc`` or both must be specified as an extra.
+* ``pyhive`` and ``pyodbc`` are now optional dependencies. At least one of {``hive``, ``odbc``} must now be specified as an extra.
 
 0.5.0: 2021-02-25
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Also provides SQLAlchemy Dialects using ``pyhive`` and ``pyodbc`` for Databricks
 Installation
 ------------
 
-Install using pip. You *must* specify at least one of the extras {``hive`` or ``odbc``}. Hive uses ``sasl`` which requires ``libsasl`` at installation time to compile. For ``odbc`` the `Simba driver <https://databricks.com/spark/odbc-driver-download>`__ is required:
+Install using pip. You *must* specify at least one of the extras {``hive`` or ``odbc``}. For ``odbc`` the `Simba driver <https://databricks.com/spark/odbc-driver-download>`__ is required:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -16,18 +16,18 @@ Also provides SQLAlchemy Dialects using ``pyhive`` and ``pyodbc`` for Databricks
 Installation
 ------------
 
-Install using pip:
+Install using pip. You *must* specify at least one of the extras {``hive`` or ``odbc``}. Hive uses ``sasl`` which requires ``libsasl`` at installation time to compile. For ``odbc`` the `Simba driver <https://databricks.com/spark/odbc-driver-download>`__ is required:
 
 .. code-block:: bash
 
-    pip install databricks-dbapi
+    pip install databricks-dbapi[hive,odbc]
 
 
 For SQLAlchemy support install with:
 
 .. code-block:: bash
 
-    pip install databricks-dbapi[sqlalchemy]
+    pip install databricks-dbapi[hive,odbc,sqlalchemy]
 
 Usage
 -----

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,7 +120,7 @@ name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -239,10 +239,10 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyhive"
-version = "0.6.3"
+version = "0.6.4"
 description = "Python interface to Hive"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -257,13 +257,14 @@ hive = ["sasl (>=0.2.1)", "thrift (>=0.10.0)", "thrift_sasl (>=0.1.0)"]
 kerberos = ["requests_kerberos (>=0.12.0)"]
 presto = ["requests (>=1.0.0)"]
 sqlalchemy = ["sqlalchemy (>=1.3.0)"]
+trino = ["requests (>=1.0.0)"]
 
 [[package]]
 name = "pyodbc"
 version = "4.0.30"
 description = "DB API Module for ODBC"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -307,7 +308,7 @@ name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
@@ -340,7 +341,7 @@ name = "sasl"
 version = "0.2.1"
 description = "Cyrus-SASL bindings for Python"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -387,7 +388,7 @@ name = "thrift"
 version = "0.13.0"
 description = "Python bindings for the Apache Thrift RPC system"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -403,7 +404,7 @@ name = "thrift-sasl"
 version = "0.3.0"
 description = "Thrift SASL Python module that implements SASL transports for Thrift (`TSaslClientTransport`)."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -472,12 +473,14 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [extras]
+hive = ["pyhive"]
+odbc = ["pyodbc"]
 sqlalchemy = ["sqlalchemy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "~2.7 || ^3.5"
-content-hash = "96016a0f1518f5e8c94add0946230f6006d1ee84cf30f70416f94177bd2c064b"
+content-hash = "61d460943c48cc06943e874d38c02636fdae474b02d8869247be572c5e6bd1ed"
 
 [metadata.files]
 appdirs = [
@@ -497,6 +500,7 @@ attrs = [
     {file = "backports.functools_lru_cache-1.6.1.tar.gz", hash = "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"},
 ]
 black = [
+    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 click = [
@@ -566,7 +570,7 @@ py = [
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pyhive = [
-    {file = "PyHive-0.6.3.tar.gz", hash = "sha256:00fe5b9a4289b5d40d3ccb7bad52a76982f485c7350a792a80d31277d26a7fd1"},
+    {file = "PyHive-0.6.4.tar.gz", hash = "sha256:10577bb3393e3da3d8ba68b2cfe800edcc1fbb0bf48394fb9a2701740f79665f"},
 ]
 pyodbc = [
     {file = "pyodbc-4.0.30-cp27-cp27m-win32.whl", hash = "sha256:a1af49a2f4f0abbafdc018d510e31561d3f9472725dc1d49cce3bd2e10e9ec18"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,9 +248,6 @@ python-versions = "*"
 [package.dependencies]
 future = "*"
 python-dateutil = "*"
-sasl = {version = ">=0.2.1", optional = true, markers = "extra == \"hive\""}
-thrift = {version = ">=0.10.0", optional = true, markers = "extra == \"hive\""}
-thrift_sasl = {version = ">=0.1.0", optional = true, markers = "extra == \"hive\""}
 
 [package.extras]
 hive = ["sasl (>=0.2.1)", "thrift (>=0.10.0)", "thrift_sasl (>=0.1.0)"]
@@ -337,17 +334,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "sasl"
-version = "0.2.1"
-description = "Cyrus-SASL bindings for Python"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
-
-[[package]]
 name = "scandir"
 version = "1.10.0"
 description = "scandir, a better directory iterator and faster os.walk()"
@@ -385,7 +371,7 @@ pymysql = ["pymysql"]
 
 [[package]]
 name = "thrift"
-version = "0.13.0"
+version = "0.15.0"
 description = "Python bindings for the Apache Thrift RPC system"
 category = "main"
 optional = true
@@ -398,18 +384,6 @@ six = ">=1.7.2"
 all = ["tornado (>=4.0)", "twisted"]
 tornado = ["tornado (>=4.0)"]
 twisted = ["twisted"]
-
-[[package]]
-name = "thrift-sasl"
-version = "0.3.0"
-description = "Thrift SASL Python module that implements SASL transports for Thrift (`TSaslClientTransport`)."
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-sasl = ">=0.2.1"
-thrift = ">=0.10.0"
 
 [[package]]
 name = "toml"
@@ -473,14 +447,14 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [extras]
-hive = ["pyhive"]
+hive = ["pyhive", "thrift"]
 odbc = ["pyodbc"]
 sqlalchemy = ["sqlalchemy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "~2.7 || ^3.5"
-content-hash = "61d460943c48cc06943e874d38c02636fdae474b02d8869247be572c5e6bd1ed"
+content-hash = "b5810bd3e3c93e8de9c7e2ae5bddd74880d2b78bffcc9508088311daa617f7c2"
 
 [metadata.files]
 appdirs = [
@@ -648,9 +622,6 @@ regex = [
     {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
-sasl = [
-    {file = "sasl-0.2.1.tar.gz", hash = "sha256:04f22e17bbebe0cd42471757a48c2c07126773c38741b1dad8d9fe724c16289d"},
-]
 scandir = [
     {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
     {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
@@ -709,10 +680,7 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.22.tar.gz", hash = "sha256:758fc8c4d6c0336e617f9f6919f9daea3ab6bb9b07005eda9a1a682e24a6cacc"},
 ]
 thrift = [
-    {file = "thrift-0.13.0.tar.gz", hash = "sha256:9af1c86bf73433afc6010ed376a6c6aca2b54099cc0d61895f640870a9ae7d89"},
-]
-thrift-sasl = [
-    {file = "thrift_sasl-0.3.0.tar.gz", hash = "sha256:80e015290e7c9afc5b4864bfb964e841d4d98e1d70f74bc216cf269f243f3362"},
+    {file = "thrift-0.15.0.tar.gz", hash = "sha256:87c8205a71cf8bbb111cb99b1f7495070fbc9cabb671669568854210da5b3e29"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,13 @@ include = ["CHANGELOG.rst"]
 
 [tool.poetry.extras]
 sqlalchemy = ["sqlalchemy"]
-hive = ["pyhive"]
+hive = ["pyhive", "thrift"]
 odbc = ["pyodbc"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
-pyhive = {version = "^0.6.1", extras = ["hive"], optional = true}
+pyhive = {version = "^0.6.1", optional = true}
+thrift = {version = "^0.15.0", optional = true}
 sqlalchemy = {version = "^1.3", optional = true}
 pyodbc = {version = "^4.0.30", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,14 @@ include = ["CHANGELOG.rst"]
 
 [tool.poetry.extras]
 sqlalchemy = ["sqlalchemy"]
+hive = ["pyhive"]
+odbc = ["pyodbc"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
-pyhive = {version = "^0.6.1", extras = ["hive"]}
+pyhive = {version = "^0.6.1", extras = ["hive"], optional = true}
 sqlalchemy = {version = "^1.3", optional = true}
-pyodbc = "^4.0.30"
+pyodbc = {version = "^4.0.30", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = {version = "^20.8b1", python = "^3.7" }


### PR DESCRIPTION
Closes #17 
Closes #19 

Removes `pyhive` and `pyodbc` as required dependencies, allowing for hive or odbc dependencies to be specified as an extra. At least one of these extras must be specified.

Using hive no longers requires `sasl` or `thrift-sasl`.