### PR TITLE
change dialect identifiers to string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Release History
 ~~~~~~~~~~~~~~~~~
 
 * ``pyhive`` and ``pyodbc`` are now optional dependencies. At least one of {``hive``, ``odbc``} must now be specified as an extra.
+* Change driver and dialect identifiers from bytes to string.
 
 0.5.0: 2021-02-25
 ~~~~~~~~~~~~~~~~~

--- a/databricks_dbapi/sqlalchemy_dialects/hive.py
+++ b/databricks_dbapi/sqlalchemy_dialects/hive.py
@@ -3,8 +3,8 @@ from databricks_dbapi.sqlalchemy_dialects.base import DatabricksDialectBase
 
 
 class DatabricksPyhiveDialect(DatabricksDialectBase):
-    name = b"databricks"
-    driver = b"pyhive"
+    name = "databricks"
+    driver = "pyhive"
 
     @classmethod
     def dbapi(cls):

--- a/databricks_dbapi/sqlalchemy_dialects/odbc.py
+++ b/databricks_dbapi/sqlalchemy_dialects/odbc.py
@@ -5,8 +5,8 @@ from databricks_dbapi.sqlalchemy_dialects.base import DatabricksDialectBase
 
 
 class DatabricksPyodbcDialect(DatabricksDialectBase, PyODBCConnector):
-    name = b"databricks"
-    driver = b"pyodbc"
+    name = "databricks"
+    driver = "pyodbc"
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
These were originally set as bytes because that's how they are in pyhive. Other SQLAlchemy dialects just use strings.

Closes #16 